### PR TITLE
Actions: build testing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Build winarg
+      working-directory: ./winarg
+      run: cargo build
     - name: Quick tests
       working-directory: ./winarg
       run: cargo test --verbose
+    - name: Build ./testing
+      working-directory: ./testing
+      run: cargo build
+    - name: Build exhaustive tests
+      working-directory: ./testing
+      run: cargo test --no-run
+      


### PR DESCRIPTION
Builds the `./testing` crate a builds the exhaustive test but does not run it.